### PR TITLE
Fix unexpected first separator without headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* [fix] unexpected item separator, that placed before first item without section header or after last section footter.
 
 ## 1.1.0
 

--- a/lib/list_view_with_data_source.dart
+++ b/lib/list_view_with_data_source.dart
@@ -160,9 +160,11 @@ final class ListViewWithDataSource<SECTION, ITEM> extends StatelessWidget {
         final indexInDataSource = index - (headerBuilder != null ? 1 : 0);
         final metaItem = dataSource.metaItem(indexInDataSource);
         final nextMetaItem = dataSource.nextMetaItem(indexInDataSource);
+
         return switch (metaItem) {
           (final ListViewDataSourceItemSectionHeader<SECTION, ITEM> item) =>
-            nextMetaItem is ListViewDataSourceItem<SECTION, ITEM>
+            nextMetaItem is ListViewDataSourceItem<SECTION, ITEM> &&
+                    sectionHeaderBuilder != null
                 ? itemSeparatorBuilder?.call(
                       context,
                       item.section,
@@ -185,12 +187,14 @@ final class ListViewWithDataSource<SECTION, ITEM> extends StatelessWidget {
                 ) ??
                 const SizedBox.shrink(),
           (final ListViewDataSourceItemSectionFooter<SECTION, ITEM> item) =>
-            sectionSeparatorBuilder?.call(
-                  context,
-                  item.section,
-                  item.sectionIndex,
-                ) ??
-                const SizedBox.shrink(),
+            sectionFooterBuilder != null && nextMetaItem != null
+                ? sectionSeparatorBuilder?.call(
+                      context,
+                      item.section,
+                      item.sectionIndex,
+                    ) ??
+                    const SizedBox.shrink()
+                : const SizedBox.shrink(),
         };
       },
       itemCount: itemCount,

--- a/test/list_view_with_data_source_test.dart
+++ b/test/list_view_with_data_source_test.dart
@@ -95,6 +95,27 @@ void main() {
     );
   }
 
+  Widget buildAppWithFooterOnly(
+    ListViewDataSource<MyFavoriteCategory, MyFavoriteItems> dataSource,
+  ) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ListViewWithDataSource<MyFavoriteCategory, MyFavoriteItems>(
+          dataSource: dataSource,
+          itemBuilder: (context, section, item, sectionIndex, itemIndex) {
+            return Text('Item: $item');
+          },
+          itemSeparatorBuilder:
+              (context, section, item, sectionIndex, itemIndex,
+                  {required insideSection}) {
+            return Text('Separator: $sectionIndex, $itemIndex, $insideSection');
+          },
+          footerBuilder: (context) => const Text('Footer of list'),
+        ),
+      ),
+    );
+  }
+
   testWidgets('Build section with items', (tester) async {
     final dataSource = ListViewDataSource<MyFavoriteCategory, MyFavoriteItems>()
       ..addSection(MyFavoriteCategory.fruits)
@@ -168,6 +189,23 @@ void main() {
     expect(find.text('Item: MyFavoriteItems.guitar'), findsOneWidget);
     expect(find.text('Footer of section: MyFavoriteCategory.instruments'),
         findsOneWidget);
+    expect(find.text('Footer of list'), findsOneWidget);
+  });
+
+  testWidgets('Build one item and footer only', (tester) async {
+    final dataSource = ListViewDataSource<MyFavoriteCategory, MyFavoriteItems>()
+      ..addSection(MyFavoriteCategory.fruits)
+      ..appendItems(MyFavoriteCategory.fruits, [MyFavoriteItems.apple]);
+
+    await tester.pumpWidget(buildAppWithFooterOnly(dataSource));
+
+    expect(find.text('Header of list'), findsNothing);
+    expect(find.text('Header of section: MyFavoriteCategory.fruits'),
+        findsNothing);
+    // ヘッダー類が一切ない場合にも、最初のアイテムの前にセパレーターが表示される不具合
+    expect(find.text('Separator: 0, null, false'), findsNothing);
+    expect(find.text('Item: MyFavoriteItems.apple'), findsOneWidget);
+    expect(find.text('Separator: 0, 0, false'), findsOneWidget);
     expect(find.text('Footer of list'), findsOneWidget);
   });
 }


### PR DESCRIPTION
closes #12 

## changes

以下の問題を修正します。

- セクションヘッダーがないときに、先頭に itemSeparator を描画してしまう
- 最後のセクションフッターの後に sectionSeparator を描画してしまう